### PR TITLE
Drain pipeline queue on pool Put()

### DIFF
--- a/extra/pool/pool_test.go
+++ b/extra/pool/pool_test.go
@@ -24,3 +24,29 @@ func TestPool(t *T) {
 
 	pool.Empty()
 }
+
+func TestPoolPutWithNonEmptyPipeline(t *T) {
+	pool, err := NewPool("tcp", "localhost:6379", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := pool.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn.Append("set", "mykey", "1")
+	pool.Put(conn)
+
+	newConn, newErr := pool.Get()
+	if newErr != nil {
+		t.Fatal(err)
+	}
+
+	if replyErr := newConn.GetReply().Err; replyErr != redis.PipelineQueueEmptyError {
+		t.Fatal("Fresh connection from pool has non-empty pipeline")
+	}
+
+	pool.Empty()
+}


### PR DESCRIPTION
Hi,

Thanks for radix! I've been really happy using it in my project.

I ran into a small issue with the pool. In my project, I use a `limit` parameter to limit the number of items returned. Sometimes I'll pipeline a number of requests to redis (say, 1000) but only call `GetReply()` on the first 100, based on either the `limit` or some other condition. After doing this, I return the redis connection back to the pool. This leads to a weird situation where I see previous replies because the `Append()` and `GetReply()` calls are no longer in sync.

In my project, this was easy to track down, but I imagine it could be a puzzling source of bugs where complex logic was involved. Please review the attached pull and let me know if you'd like any tweaks.